### PR TITLE
ci: Do not require checks to pass to automerge ready PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,4 +15,3 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           reviewers: false
-          checks_enabled: true


### PR DESCRIPTION
Some checks will be skipped and we still want to merge in those cases.